### PR TITLE
Add missing <string> header

### DIFF
--- a/src/location_service/com/ubuntu/location/service/state.cpp
+++ b/src/location_service/com/ubuntu/location/service/state.cpp
@@ -15,7 +15,7 @@
  *
  * Authored by: Thomas Voß <thomas.voss@canonical.com>
  */
-
+#include <string>
 #include <com/ubuntu/location/service/state.h>
 
 #include <map>


### PR DESCRIPTION
The string header in this file is missing, which cause failure at build time.